### PR TITLE
Fix anti ingredient zones not removing wood meshes

### DIFF
--- a/Assets/Code/Scripts/AntiIngredientZone.cs
+++ b/Assets/Code/Scripts/AntiIngredientZone.cs
@@ -57,8 +57,8 @@ public class AntiIngredientZone : MonoBehaviour
 
             Vector3 originalScale = ingredient.transform.localScale;
 
-            GameObject desteroyIngridenseEffekt = ingredient.transform.Find("DestoryItem").gameObject;
-            if(desteroyIngridenseEffekt != null)
+            GameObject desteroyIngridenseEffekt = ingredient?.transform.Find("DestoryItem")?.gameObject;
+            if (desteroyIngridenseEffekt != null)
             {
                 desteroyIngridenseEffekt.SetActive(true);
             }


### PR DESCRIPTION
This pull request fixes a problem caused due to a missing null check in the AntiIngredientZone.KillIngredient()-coroutine:
```cs
GameObject desteroyIngridenseEffekt = ingredient.transform.Find("DestoryItem").gameObject;
```
A piece of wood is not an ingredient, so this assignment will fail. I fixed this by using the null-conditional operator, but another if-statement could also be used for increased readability.

![image](https://github.com/takennot/BrewBesties/assets/47401343/d81c6114-0ce1-47d5-9552-2898d20daee8)
![image](https://github.com/takennot/BrewBesties/assets/47401343/9d534829-3de2-44b9-9da0-2cf3e6495df7)
